### PR TITLE
Fix capitalization on wNumb.js import

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 	<script type="text/javascript" src="csvjsontest.js"></script>
 	<script type="text/javascript" src="birthplaces.js"></script>	
 	<script type="text/javascript" src="MovingMarker.js"></script>
-	<script type="text/javascript" src="Wnumb.js"></script>
+	<script type="text/javascript" src="wNumb.js"></script>
 
 	<script src="https://d3js.org/d3.v5.min.js"></script>
 	


### PR DESCRIPTION
I think GitHub.io has tighter capitalization requirements than local Web servers do, which is why this works locally.